### PR TITLE
refactor(pages): remove dynamic rendering

### DIFF
--- a/app/admin/(routes)/clothes/page.tsx
+++ b/app/admin/(routes)/clothes/page.tsx
@@ -7,8 +7,6 @@ import { ClothesView } from '@/modules/clothes/ui/views/clothes-view'
 
 import { LoadingState } from '@/components/loading-state'
 
-export const dynamic = 'force-dynamic'
-
 export default async function ClothesPage() {
   await requireRole('admin')
 

--- a/app/admin/(routes)/customers/page.tsx
+++ b/app/admin/(routes)/customers/page.tsx
@@ -5,8 +5,6 @@ import { CustomerView } from '@/modules/admin/ui/views/customer-view'
 
 import { LoadingState } from '@/components/loading-state'
 
-export const dynamic = 'force-dynamic'
-
 export default function CustomerPage() {
   return (
     <div className='mx-auto flex h-full w-full max-w-7xl flex-col gap-y-4 px-4 py-4 md:px-6 md:py-6'>

--- a/app/admin/(routes)/employees/[employeeId]/page.tsx
+++ b/app/admin/(routes)/employees/[employeeId]/page.tsx
@@ -2,9 +2,6 @@ import { requireRole } from '@/lib/dal'
 
 import { EmployeeIdView } from '@/modules/admin/ui/views/employee-id-view'
 
-// Forzar renderizado dinámico porque usamos cookies para autenticación
-export const dynamic = 'force-dynamic'
-
 export default async function AdminEmployeeIdPage() {
   await requireRole('admin')
 

--- a/app/admin/(routes)/employees/page.tsx
+++ b/app/admin/(routes)/employees/page.tsx
@@ -7,9 +7,6 @@ import { EmployeeView } from '@/modules/admin/ui/views'
 
 import { LoadingState } from '@/components/loading-state'
 
-// Forzar renderizado dinámico porque usamos cookies para autenticación
-export const dynamic = 'force-dynamic'
-
 export default async function AdminEmployeesPage() {
   await requireRole('admin')
 

--- a/app/admin/(routes)/quotes/[id]/page.tsx
+++ b/app/admin/(routes)/quotes/[id]/page.tsx
@@ -4,23 +4,23 @@ import { notFound } from 'next/navigation'
 
 import { requireRole } from '@/lib/dal'
 
-import { getClotheById } from '@/modules/clothes/server/queries'
-import { ClotheDetailView } from '@/modules/clothes/ui/views/clothe-detail-view'
+import { getQuoteById } from '@/modules/quotes/server/queries'
+import { QuoteDetailView } from '@/modules/quotes/ui/views/quote-detail-view'
 
 import { LoadingState } from '@/components/loading-state'
 
-interface ClothePageProps {
+interface QuotePageProps {
   params: Promise<{ id: string }>
 }
 
-export default async function ClothePage({ params }: ClothePageProps) {
+export default async function QuotePage({ params }: QuotePageProps) {
   await requireRole('admin')
 
   const { id } = await params
 
-  const clothe = await getClotheById(id)
+  const quote = await getQuoteById(id)
 
-  if (!clothe) {
+  if (!quote) {
     notFound()
   }
 
@@ -28,12 +28,12 @@ export default async function ClothePage({ params }: ClothePageProps) {
     <Suspense
       fallback={
         <LoadingState
-          title='Cargando prenda...'
+          title='Cargando cotización...'
           description='Esto puede tardar unos segundos'
         />
       }
     >
-      <ClotheDetailView clothe={clothe} />
+      <QuoteDetailView quote={quote} />
     </Suspense>
   )
 }

--- a/app/admin/(routes)/quotes/page.tsx
+++ b/app/admin/(routes)/quotes/page.tsx
@@ -1,0 +1,35 @@
+import { Suspense } from 'react'
+
+import { requireRole } from '@/lib/dal'
+
+import { QuotesView } from '@/modules/quotes/ui/views/quotes-view'
+
+import { LoadingState } from '@/components/loading-state'
+
+export default async function QuotesPage() {
+  await requireRole('admin')
+
+  return (
+    <div className='mx-auto flex h-full w-full max-w-7xl flex-col gap-y-4 px-4 py-4 md:px-6 md:py-6'>
+      <div className='flex items-center justify-between'>
+        <div>
+          <h1 className='text-3xl font-semibold'>Cotizaciones</h1>
+          <p className='text-muted-foreground mt-1'>
+            Gestiona las cotizaciones de tus clientes
+          </p>
+        </div>
+      </div>
+
+      <Suspense
+        fallback={
+          <LoadingState
+            title='Cargando cotizaciones...'
+            description='Esto puede tardar unos segundos'
+          />
+        }
+      >
+        <QuotesView />
+      </Suspense>
+    </div>
+  )
+}

--- a/app/admin/layout.tsx
+++ b/app/admin/layout.tsx
@@ -1,5 +1,6 @@
 import { getUser } from '@/lib/dal'
 
+import { getCustomers } from '@/modules/admin/server/queries'
 import { AdminDashboardSidebar } from '@/modules/admin/ui/components/admin-dashboard-sidebar'
 
 import { DashboardNavbar } from '@/components/dashboard-navbar'
@@ -19,12 +20,15 @@ export default async function AdminLayout({
     return null
   }
 
+  const customersData = await getCustomers()
+  const customers = customersData?.items || []
+
   return (
     <SidebarProvider>
       <AdminDashboardSidebar user={user} />
 
       <div className='bg-muted flex min-h-svh w-full flex-1 flex-col overflow-hidden'>
-        <DashboardNavbar />
+        <DashboardNavbar customers={customers} />
 
         <main className='flex-1 overflow-y-auto'>{children}</main>
       </div>


### PR DESCRIPTION
This pull request primarily removes dynamic rendering enforcement from several admin route pages and introduces new pages for managing quotes in the admin section. Additionally, it updates the admin layout to provide customer data to the dashboard navigation. These changes improve performance by allowing static rendering where possible and enhance the admin dashboard with new quote management features and customer context.

### Removal of dynamic rendering enforcement

* Removed the `export const dynamic = 'force-dynamic'` directive from multiple admin route pages, including clothes, customers, employees, and quotes. This allows Next.js to statically render these pages when possible, improving performance. ([app/admin/(routes)/clothes/[id]/page.tsxL12-L13](diffhunk://#diff-8b1bf47fdc43ae0649137ad7e9c7976b8eb7fb1907187511de263510a28accedL12-L13), [[1]](diffhunk://#diff-82db87f27aa9bd35d53b234f48bedb2d916fd8bf43cf902c4e9a694065de0af6L10-L11) [[2]](diffhunk://#diff-49e895e3973fb225656c184f80aaf6c3c6d6a8848484a23b0967d363cbfb0812L8-L9) [app/admin/(routes)/employees/[employeeId]/page.tsxL5-L7](diffhunk://#diff-53e728c976ed8ae872f8ae2a13694823d233356c2c0b067a4286a17d40f2e5b6L5-L7), [[3]](diffhunk://#diff-61c05b4841c52849c100bcc6577d32e2d74f7ebf9b9dbb1084da3523b7005927L10-L12)

### Addition of quotes management pages

* Added a new `quotes/page.tsx` file for listing quotes, including a suspense fallback with a loading state and a `QuotesView` component for displaying the quotes.
* Added a new `quotes/[id]/page.tsx` file for viewing quote details, with suspense fallback and error handling if the quote is not found. ([app/admin/(routes)/quotes/[id]/page.tsxR1-R39](diffhunk://#diff-7fafeb9141b98a2d6c12b81e9bd1043b445c46556d21f70b298fb0135c1d21a2R1-R39))

### Admin layout improvements

* Updated `app/admin/layout.tsx` to fetch customer data using `getCustomers` and pass the customer list to `DashboardNavbar` for enhanced navigation context. [[1]](diffhunk://#diff-6fa56e6c12ff32a2a97be470045bc4e18ef6e5aebf125444eb48feb43251bf91R3) [[2]](diffhunk://#diff-6fa56e6c12ff32a2a97be470045bc4e18ef6e5aebf125444eb48feb43251bf91R23-R31)