### PR TITLE
feat(orders): add orders management

### DIFF
--- a/app/admin/(routes)/orders/page.tsx
+++ b/app/admin/(routes)/orders/page.tsx
@@ -1,0 +1,35 @@
+import { Suspense } from 'react'
+
+import { requireRole } from '@/lib/dal'
+
+import { getOrders } from '@/modules/orders/server/queries'
+import { OrdersView } from '@/modules/orders/ui/views'
+import { getPendingQuotes } from '@/modules/quotes/server/queries'
+
+import { LoadingState } from '@/components/loading-state'
+
+export default async function OrdersPage() {
+  await requireRole('admin')
+
+  const [ordersData, pendingQuotes] = await Promise.all([
+    getOrders(),
+    getPendingQuotes()
+  ])
+
+  const orders = ordersData?.items || []
+
+  return (
+    <div className='mx-auto flex h-full w-full max-w-7xl flex-col gap-y-4 px-4 py-4 md:px-6 md:py-6'>
+      <Suspense
+        fallback={
+          <LoadingState
+            title='Cargando órdenes...'
+            description='Por favor espera un momento'
+          />
+        }
+      >
+        <OrdersView orders={orders} pendingQuotes={pendingQuotes} />
+      </Suspense>
+    </div>
+  )
+}

--- a/modules/admin/ui/components/admin-dashboard-sidebar.tsx
+++ b/modules/admin/ui/components/admin-dashboard-sidebar.tsx
@@ -6,6 +6,7 @@ import { usePathname } from 'next/navigation'
 
 import {
   BackpackIcon,
+  PackageIcon,
   StarIcon,
   UsersIcon,
   UserStarIcon,
@@ -49,6 +50,11 @@ const firstSection = [
     icon: WalletIcon,
     label: 'Cotizaciones',
     href: '/admin/quotes'
+  },
+  {
+    icon: PackageIcon,
+    label: 'Órdenes',
+    href: '/admin/orders'
   }
 ]
 

--- a/modules/orders/schemas.ts
+++ b/modules/orders/schemas.ts
@@ -1,0 +1,42 @@
+import { z } from 'zod'
+
+// Validación de fecha: mínimo 7 días, máximo 60 días desde hoy
+const minDeliveryDate = new Date()
+minDeliveryDate.setDate(minDeliveryDate.getDate() + 7)
+
+const maxDeliveryDate = new Date()
+maxDeliveryDate.setDate(maxDeliveryDate.getDate() + 60)
+
+export const createOrderSchema = z.object({
+  quoteId: z.string().min(1, 'Debe seleccionar una cotización'),
+  deliveryDate: z
+    .date({
+      message: 'La fecha de entrega es obligatoria'
+    })
+    .refine(
+      date => date >= minDeliveryDate,
+      'La fecha de entrega debe ser al menos 7 días desde hoy'
+    )
+    .refine(
+      date => date <= maxDeliveryDate,
+      'La fecha de entrega no puede ser mayor a 60 días desde hoy'
+    ),
+  department: z
+    .string()
+    .min(1, 'El departamento es obligatorio')
+    .max(100, 'El departamento no puede exceder 100 caracteres'),
+  city: z
+    .string()
+    .min(1, 'La ciudad es obligatoria')
+    .max(100, 'La ciudad no puede exceder 100 caracteres'),
+  district: z
+    .string()
+    .min(1, 'El distrito es obligatorio')
+    .max(100, 'El distrito no puede exceder 100 caracteres'),
+  street: z
+    .string()
+    .min(1, 'La calle es obligatoria')
+    .max(200, 'La calle no puede exceder 200 caracteres')
+})
+
+export type CreateOrderFormData = z.infer<typeof createOrderSchema>

--- a/modules/orders/server/actions.ts
+++ b/modules/orders/server/actions.ts
@@ -1,0 +1,114 @@
+'use server'
+
+import { revalidateTag } from 'next/cache'
+import { cookies } from 'next/headers'
+
+import { apiBaseUrl } from '@/db'
+
+import { createOrderSchema } from '../schemas'
+import { Order } from '../types'
+
+export const createOrderAction = async (formData: FormData) => {
+  try {
+    // Parse form data
+    const quoteId = formData.get('quoteId') as string
+    const deliveryDateStr = formData.get('deliveryDate') as string
+    const department = formData.get('department') as string
+    const city = formData.get('city') as string
+    const district = formData.get('district') as string
+    const street = formData.get('street') as string
+
+    // Parse delivery date
+    const deliveryDate = deliveryDateStr ? new Date(deliveryDateStr) : null
+
+    if (!deliveryDate) {
+      return {
+        success: false as const,
+        message: 'Fecha de entrega inválida'
+      }
+    }
+
+    // Validate with Zod
+    const validatedData = createOrderSchema.safeParse({
+      quoteId,
+      deliveryDate,
+      department,
+      city,
+      district,
+      street
+    })
+
+    if (!validatedData.success) {
+      return {
+        success: false as const,
+        errors: validatedData.error.flatten().fieldErrors,
+        message: 'Por favor, verifica los datos ingresados.'
+      }
+    }
+
+    // Get auth cookies
+    const cookieStore = await cookies()
+    const accessToken = cookieStore.get('sAccessToken')?.value
+    const refreshToken = cookieStore.get('sRefreshToken')?.value
+    const frontToken = cookieStore.get('sFrontToken')?.value
+    const antiCsrf =
+      cookieStore.get('sAntiCsrf')?.value || cookieStore.get('anti-csrf')?.value
+
+    if (!accessToken || !antiCsrf) {
+      return {
+        success: false as const,
+        message: 'No estás autenticado. Por favor, inicia sesión.'
+      }
+    }
+
+    // Create order
+    const response = await fetch(`${apiBaseUrl}/orders`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Cookie: `sAccessToken=${accessToken}; sRefreshToken=${refreshToken}; sFrontToken=${frontToken}`,
+        'anti-csrf': antiCsrf
+      },
+      body: JSON.stringify({
+        quoteId: validatedData.data.quoteId,
+        deliveryDate: validatedData.data.deliveryDate.toISOString(),
+        address: {
+          department: validatedData.data.department,
+          city: validatedData.data.city,
+          district: validatedData.data.district,
+          street: validatedData.data.street
+        }
+      }),
+      cache: 'no-store'
+    })
+
+    if (!response.ok) {
+      const errorData = await response.json().catch(() => ({}))
+      console.error('Error creating order:', errorData)
+      return {
+        success: false as const,
+        message:
+          errorData.message ||
+          'Error al crear la orden. Por favor, intenta de nuevo.'
+      }
+    }
+
+    const order: Order = await response.json()
+
+    // Revalidate cache
+    revalidateTag('orders')
+    revalidateTag('quotes') // También revalidamos quotes porque el estado cambió
+
+    return {
+      success: true as const,
+      data: order,
+      message: 'Orden creada exitosamente'
+    }
+  } catch (error) {
+    console.error('Error in createOrderAction:', error)
+    return {
+      success: false as const,
+      message: 'Ocurrió un error inesperado. Por favor, intenta de nuevo.'
+    }
+  }
+}

--- a/modules/orders/server/queries.ts
+++ b/modules/orders/server/queries.ts
@@ -1,0 +1,87 @@
+'use server'
+
+import { cache } from 'react'
+
+import { cookies } from 'next/headers'
+
+import { apiBaseUrl } from '@/db'
+
+import { GetOrdersResponse, Order } from '../types'
+
+export const getOrders = cache(async (): Promise<GetOrdersResponse | null> => {
+  try {
+    const cookieStore = await cookies()
+    const accessToken = cookieStore.get('sAccessToken')?.value
+    const refreshToken = cookieStore.get('sRefreshToken')?.value
+    const frontToken = cookieStore.get('sFrontToken')?.value
+
+    if (!accessToken) {
+      return null
+    }
+
+    const response = await fetch(`${apiBaseUrl}/orders`, {
+      headers: {
+        Cookie: `sAccessToken=${accessToken}; sRefreshToken=${refreshToken}; sFrontToken=${frontToken}`
+      },
+      next: {
+        revalidate: 60,
+        tags: ['orders']
+      }
+    })
+
+    if (!response.ok) {
+      console.error('Error fetching orders:', response.statusText)
+      return null
+    }
+
+    const data = await response.json()
+
+    // El backend puede devolver array directo o objeto con items
+    if (Array.isArray(data)) {
+      return {
+        items: data,
+        total: data.length,
+        page: 1,
+        limit: data.length
+      }
+    }
+
+    return data
+  } catch (error) {
+    console.error('Error in getOrders:', error)
+    return null
+  }
+})
+
+export const getOrderById = cache(async (id: string): Promise<Order | null> => {
+  try {
+    const cookieStore = await cookies()
+    const accessToken = cookieStore.get('sAccessToken')?.value
+    const refreshToken = cookieStore.get('sRefreshToken')?.value
+    const frontToken = cookieStore.get('sFrontToken')?.value
+
+    if (!accessToken) {
+      return null
+    }
+
+    const response = await fetch(`${apiBaseUrl}/orders/${id}`, {
+      headers: {
+        Cookie: `sAccessToken=${accessToken}; sRefreshToken=${refreshToken}; sFrontToken=${frontToken}`
+      },
+      next: {
+        revalidate: 60,
+        tags: ['orders', `order-${id}`]
+      }
+    })
+
+    if (!response.ok) {
+      console.error('Error fetching order:', response.statusText)
+      return null
+    }
+
+    return response.json()
+  } catch (error) {
+    console.error('Error in getOrderById:', error)
+    return null
+  }
+})

--- a/modules/orders/types.ts
+++ b/modules/orders/types.ts
@@ -1,0 +1,53 @@
+export interface Address {
+  id: string
+  department: string
+  city: string
+  district: string
+  street: string
+}
+
+export interface Order {
+  id: string
+  total: string | number
+  deliveryDate: string
+  status: 'IN_PRODUCTION' | 'DELIVERED' | 'CANCELLED'
+  quoteId: string
+  addressId?: string
+  address?: Address
+  customer?: {
+    id: string
+    names: string
+    lastNames: string
+    phone: string
+  }
+  quote?: {
+    id: string
+    customerId: string
+    customer?: {
+      id: string
+      names: string
+      lastNames: string
+    }
+  }
+  totalClothes?: number
+  totalUnitsToProduced?: number
+  createdAt: string
+}
+
+export interface GetOrdersResponse {
+  items: Order[]
+  total: number
+  page: number
+  limit: number
+}
+
+export interface CreateOrderInput {
+  quoteId: string
+  deliveryDate: string
+  address: {
+    department: string
+    city: string
+    district: string
+    street: string
+  }
+}

--- a/modules/orders/ui/components/order-form.tsx
+++ b/modules/orders/ui/components/order-form.tsx
@@ -1,0 +1,381 @@
+'use client'
+
+import { useState } from 'react'
+
+import { useRouter } from 'next/navigation'
+
+import {
+  CalendarIcon,
+  Check,
+  ChevronsUpDown,
+  OctagonAlertIcon
+} from 'lucide-react'
+
+import { zodResolver } from '@hookform/resolvers/zod'
+import { format } from 'date-fns'
+import { es } from 'date-fns/locale'
+import { useForm } from 'react-hook-form'
+
+import { cn } from '@/lib/utils'
+
+import {
+  CreateOrderFormData,
+  createOrderSchema
+} from '@/modules/orders/schemas'
+import { createOrderAction } from '@/modules/orders/server/actions'
+import { Quote } from '@/modules/quotes/types'
+
+import { Alert, AlertDescription } from '@/components/ui/alert'
+import { Button } from '@/components/ui/button'
+import { Calendar } from '@/components/ui/calendar'
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList
+} from '@/components/ui/command'
+import {
+  Form,
+  FormControl,
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage
+} from '@/components/ui/form'
+import { Input } from '@/components/ui/input'
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger
+} from '@/components/ui/popover'
+
+interface OrderFormProps {
+  pendingQuotes: Quote[]
+  onSuccess?: () => void
+  onCancel?: () => void
+}
+
+export const OrderForm = ({
+  pendingQuotes,
+  onSuccess,
+  onCancel
+}: OrderFormProps) => {
+  const [isLoading, setIsLoading] = useState(false)
+  const [errorMessage, setErrorMessage] = useState<string | null>(null)
+  const router = useRouter()
+
+  const form = useForm<CreateOrderFormData>({
+    resolver: zodResolver(createOrderSchema),
+    defaultValues: {
+      quoteId: '',
+      deliveryDate: undefined,
+      department: '',
+      city: '',
+      district: '',
+      street: ''
+    }
+  })
+
+  const onSubmit = async (data: CreateOrderFormData) => {
+    setIsLoading(true)
+    setErrorMessage(null)
+
+    try {
+      const formData = new FormData()
+      formData.append('quoteId', data.quoteId)
+      formData.append('deliveryDate', data.deliveryDate.toISOString())
+      formData.append('department', data.department)
+      formData.append('city', data.city)
+      formData.append('district', data.district)
+      formData.append('street', data.street)
+
+      const result = await createOrderAction(formData)
+
+      if (!result.success) {
+        if ('errors' in result && result.errors) {
+          Object.entries(result.errors).forEach(([key, value]) => {
+            if (value && value[0]) {
+              form.setError(key as keyof CreateOrderFormData, {
+                message: value[0]
+              })
+            }
+          })
+        }
+
+        if (result.message) {
+          setErrorMessage(result.message)
+        }
+      } else {
+        form.reset()
+        if (onSuccess) {
+          onSuccess()
+        }
+        router.push('/admin/orders')
+      }
+    } catch (error) {
+      console.error('Error submitting form:', error)
+      setErrorMessage(
+        'Ocurrió un error inesperado. Por favor, intenta de nuevo.'
+      )
+    } finally {
+      setIsLoading(false)
+    }
+  }
+
+  // Calcular fechas mínima y máxima
+  const minDate = new Date()
+  minDate.setDate(minDate.getDate() + 7)
+
+  const maxDate = new Date()
+  maxDate.setDate(maxDate.getDate() + 60)
+
+  return (
+    <Form {...form}>
+      <form className='w-full space-y-6' onSubmit={form.handleSubmit(onSubmit)}>
+        {/* Quote Selector */}
+        <FormField
+          control={form.control}
+          name='quoteId'
+          render={({ field }) => (
+            <FormItem className='flex flex-col'>
+              <FormLabel>Cotización</FormLabel>
+              <Popover>
+                <PopoverTrigger asChild>
+                  <FormControl>
+                    <Button
+                      variant='outline'
+                      role='combobox'
+                      className={cn(
+                        'w-full justify-between',
+                        !field.value && 'text-muted-foreground'
+                      )}
+                      disabled={isLoading}
+                    >
+                      {field.value
+                        ? pendingQuotes.find(quote => quote.id === field.value)
+                            ?.customer
+                          ? `${pendingQuotes.find(quote => quote.id === field.value)?.customer?.names} ${pendingQuotes.find(quote => quote.id === field.value)?.customer?.lastNames} - ID: ${field.value.slice(0, 8)}...`
+                          : `ID: ${field.value.slice(0, 8)}...`
+                        : 'Seleccionar cotización'}
+                      <ChevronsUpDown className='ml-2 h-4 w-4 shrink-0 opacity-50' />
+                    </Button>
+                  </FormControl>
+                </PopoverTrigger>
+                <PopoverContent className='w-full p-0'>
+                  <Command>
+                    <CommandInput placeholder='Buscar cotización...' />
+                    <CommandList>
+                      <CommandEmpty>
+                        No se encontraron cotizaciones pendientes.
+                      </CommandEmpty>
+                      <CommandGroup>
+                        {pendingQuotes.map(quote => (
+                          <CommandItem
+                            key={quote.id}
+                            value={quote.id}
+                            onSelect={() => {
+                              form.setValue('quoteId', quote.id)
+                            }}
+                          >
+                            <Check
+                              className={cn(
+                                'mr-2 h-4 w-4',
+                                quote.id === field.value
+                                  ? 'opacity-100'
+                                  : 'opacity-0'
+                              )}
+                            />
+                            <div className='flex flex-col'>
+                              <span>
+                                {quote.customer
+                                  ? `${quote.customer.names} ${quote.customer.lastNames}`
+                                  : 'Cliente desconocido'}
+                              </span>
+                              <span className='text-muted-foreground text-xs'>
+                                ID: {quote.id.slice(0, 8)}... - Total: S/{' '}
+                                {typeof quote.total === 'string'
+                                  ? parseFloat(quote.total).toFixed(2)
+                                  : quote.total.toFixed(2)}
+                              </span>
+                            </div>
+                          </CommandItem>
+                        ))}
+                      </CommandGroup>
+                    </CommandList>
+                  </Command>
+                </PopoverContent>
+              </Popover>
+              <FormDescription className='text-xs'>
+                Selecciona una cotización pendiente para crear la orden
+              </FormDescription>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        {/* Delivery Date */}
+        <FormField
+          control={form.control}
+          name='deliveryDate'
+          render={({ field }) => (
+            <FormItem className='flex flex-col'>
+              <FormLabel>Fecha de Entrega</FormLabel>
+              <Popover>
+                <PopoverTrigger asChild>
+                  <FormControl>
+                    <Button
+                      variant='outline'
+                      className={cn(
+                        'w-full pl-3 text-left font-normal',
+                        !field.value && 'text-muted-foreground'
+                      )}
+                      disabled={isLoading}
+                    >
+                      {field.value ? (
+                        format(field.value, 'PPP', { locale: es })
+                      ) : (
+                        <span>Seleccionar fecha</span>
+                      )}
+                      <CalendarIcon className='ml-auto h-4 w-4 opacity-50' />
+                    </Button>
+                  </FormControl>
+                </PopoverTrigger>
+                <PopoverContent className='w-auto p-0' align='start'>
+                  <Calendar
+                    mode='single'
+                    selected={field.value}
+                    onSelect={field.onChange}
+                    disabled={date => date < minDate || date > maxDate}
+                    initialFocus
+                    locale={es}
+                  />
+                </PopoverContent>
+              </Popover>
+              <FormDescription className='text-xs'>
+                Mínimo 7 días, máximo 60 días desde hoy
+              </FormDescription>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        {/* Address Fields */}
+        <div className='space-y-4 rounded-lg border p-4'>
+          <h3 className='font-semibold'>Dirección de Entrega</h3>
+
+          <div className='grid grid-cols-1 gap-4 md:grid-cols-2'>
+            {/* Department */}
+            <FormField
+              control={form.control}
+              name='department'
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Departamento</FormLabel>
+                  <FormControl>
+                    <Input
+                      placeholder='Ej: La Libertad'
+                      disabled={isLoading}
+                      {...field}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            {/* City */}
+            <FormField
+              control={form.control}
+              name='city'
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Ciudad</FormLabel>
+                  <FormControl>
+                    <Input
+                      placeholder='Ej: Trujillo'
+                      disabled={isLoading}
+                      {...field}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            {/* District */}
+            <FormField
+              control={form.control}
+              name='district'
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Distrito</FormLabel>
+                  <FormControl>
+                    <Input
+                      placeholder='Ej: Trujillo'
+                      disabled={isLoading}
+                      {...field}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            {/* Street */}
+            <FormField
+              control={form.control}
+              name='street'
+              render={({ field }) => (
+                <FormItem className='md:col-span-2'>
+                  <FormLabel>Calle</FormLabel>
+                  <FormControl>
+                    <Input
+                      placeholder='Ej: Av. Jesus de Nazaret 390'
+                      disabled={isLoading}
+                      {...field}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+          </div>
+        </div>
+
+        {/* Error Alert */}
+        {errorMessage && (
+          <Alert
+            variant='destructive'
+            className='bg-destructive/10 flex items-center gap-x-4 border-none text-sm'
+          >
+            <div className='flex'>
+              <OctagonAlertIcon className='size-4' />
+            </div>
+            <AlertDescription>{errorMessage}</AlertDescription>
+          </Alert>
+        )}
+
+        {/* Action Buttons */}
+        <div className='flex w-full justify-stretch gap-4'>
+          {onCancel && (
+            <Button
+              type='button'
+              variant='outline'
+              onClick={onCancel}
+              disabled={isLoading}
+              className='flex-1'
+            >
+              Cancelar
+            </Button>
+          )}
+          <Button type='submit' className='flex-1' disabled={isLoading}>
+            {isLoading ? 'Creando...' : 'Crear Orden'}
+          </Button>
+        </div>
+      </form>
+    </Form>
+  )
+}

--- a/modules/orders/ui/components/orders-columns.tsx
+++ b/modules/orders/ui/components/orders-columns.tsx
@@ -1,0 +1,136 @@
+'use client'
+
+import { MoreHorizontal } from 'lucide-react'
+
+import { ColumnDef } from '@tanstack/react-table'
+import { format } from 'date-fns'
+import { es } from 'date-fns/locale'
+
+import { Order } from '@/modules/orders/types'
+
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuTrigger
+} from '@/components/ui/dropdown-menu'
+
+const formatPrice = (price: string | number): string => {
+  const numericPrice = typeof price === 'string' ? parseFloat(price) : price
+  return `S/ ${numericPrice.toFixed(2)}`
+}
+
+const getStatusBadge = (status: Order['status']) => {
+  const statusMap = {
+    IN_PRODUCTION: { label: 'En Producción', variant: 'default' as const },
+    DELIVERED: { label: 'Entregado', variant: 'secondary' as const },
+    CANCELLED: { label: 'Cancelado', variant: 'destructive' as const }
+  }
+
+  const config = statusMap[status] || {
+    label: status,
+    variant: 'default' as const
+  }
+  return <Badge variant={config.variant}>{config.label}</Badge>
+}
+
+export const ordersColumns: ColumnDef<Order>[] = [
+  {
+    accessorKey: 'id',
+    header: 'ID',
+    cell: ({ row }) => {
+      const id = row.original.id
+      return <span className='font-mono text-xs'>{id.slice(0, 8)}...</span>
+    }
+  },
+  {
+    id: 'customer',
+    header: 'Cliente',
+    cell: ({ row }) => {
+      // El backend devuelve customer directamente en order, no en quote
+      const customer = row.original.customer || row.original.quote?.customer
+      if (!customer) return <span className='text-muted-foreground'>-</span>
+      return (
+        <span>
+          {customer.names} {customer.lastNames}
+        </span>
+      )
+    }
+  },
+  {
+    accessorKey: 'total',
+    header: 'Total',
+    cell: ({ row }) => {
+      return (
+        <span className='font-semibold'>{formatPrice(row.original.total)}</span>
+      )
+    }
+  },
+  {
+    accessorKey: 'deliveryDate',
+    header: 'Fecha de Entrega',
+    cell: ({ row }) => {
+      const date = new Date(row.original.deliveryDate)
+      return <span>{format(date, 'dd MMM yyyy', { locale: es })}</span>
+    }
+  },
+  {
+    accessorKey: 'status',
+    header: 'Estado',
+    cell: ({ row }) => getStatusBadge(row.original.status)
+  },
+  {
+    id: 'address',
+    header: 'Dirección',
+    cell: ({ row }) => {
+      const address = row.original.address
+      if (!address) return <span className='text-muted-foreground'>-</span>
+      return (
+        <div className='max-w-[200px] truncate text-sm'>
+          {address.street}, {address.district}
+        </div>
+      )
+    }
+  },
+  {
+    accessorKey: 'createdAt',
+    header: 'Fecha de Creación',
+    cell: ({ row }) => {
+      const date = new Date(row.original.createdAt)
+      return (
+        <span className='text-muted-foreground text-sm'>
+          {format(date, 'dd MMM yyyy', { locale: es })}
+        </span>
+      )
+    }
+  },
+  {
+    id: 'actions',
+    cell: ({ row }) => {
+      const order = row.original
+
+      return (
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button variant='ghost' className='h-8 w-8 p-0'>
+              <span className='sr-only'>Abrir menú</span>
+              <MoreHorizontal className='h-4 w-4' />
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align='end'>
+            <DropdownMenuLabel>Acciones</DropdownMenuLabel>
+            <DropdownMenuItem
+              onClick={() => navigator.clipboard.writeText(order.id)}
+            >
+              Copiar ID
+            </DropdownMenuItem>
+            <DropdownMenuItem>Ver detalles</DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      )
+    }
+  }
+]

--- a/modules/orders/ui/views/index.ts
+++ b/modules/orders/ui/views/index.ts
@@ -1,0 +1,1 @@
+export * from './orders-view'

--- a/modules/orders/ui/views/orders-view.tsx
+++ b/modules/orders/ui/views/orders-view.tsx
@@ -1,0 +1,68 @@
+'use client'
+
+import { useState } from 'react'
+
+import { PlusIcon } from 'lucide-react'
+
+import { Order } from '@/modules/orders/types'
+import { OrderForm } from '@/modules/orders/ui/components/order-form'
+import { ordersColumns } from '@/modules/orders/ui/components/orders-columns'
+import { Quote } from '@/modules/quotes/types'
+
+import { DataTable } from '@/components/data-table'
+import { Button } from '@/components/ui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger
+} from '@/components/ui/dialog'
+
+interface OrdersViewProps {
+  orders: Order[]
+  pendingQuotes: Quote[]
+}
+
+export const OrdersView = ({ orders, pendingQuotes }: OrdersViewProps) => {
+  const [isDialogOpen, setIsDialogOpen] = useState(false)
+
+  return (
+    <div className='flex flex-col gap-6'>
+      <div className='flex items-center justify-between'>
+        <div>
+          <h1 className='text-3xl font-bold'>Órdenes</h1>
+          <p className='text-muted-foreground mt-1'>
+            Gestiona las órdenes de producción y entregas
+          </p>
+        </div>
+
+        <Dialog open={isDialogOpen} onOpenChange={setIsDialogOpen}>
+          <DialogTrigger asChild>
+            <Button>
+              <PlusIcon className='mr-2 h-4 w-4' />
+              Nueva Orden
+            </Button>
+          </DialogTrigger>
+          <DialogContent className='max-h-[90vh] overflow-y-auto sm:max-w-[600px]'>
+            <DialogHeader>
+              <DialogTitle>Crear Nueva Orden</DialogTitle>
+              <DialogDescription>
+                Selecciona una cotización pendiente y completa la información de
+                entrega
+              </DialogDescription>
+            </DialogHeader>
+            <OrderForm
+              pendingQuotes={pendingQuotes}
+              onSuccess={() => setIsDialogOpen(false)}
+              onCancel={() => setIsDialogOpen(false)}
+            />
+          </DialogContent>
+        </Dialog>
+      </div>
+
+      <DataTable columns={ordersColumns} data={orders} />
+    </div>
+  )
+}

--- a/modules/quotes/server/queries.ts
+++ b/modules/quotes/server/queries.ts
@@ -97,3 +97,16 @@ export const getQuoteById = cache(async (id: string): Promise<Quote | null> => {
     return null
   }
 })
+
+export const getPendingQuotes = cache(async (): Promise<Quote[]> => {
+  try {
+    const quotesData = await getQuotes()
+    if (!quotesData) return []
+
+    // Filtrar solo las cotizaciones con estado PENDING
+    return quotesData.items.filter(quote => quote.status === 'PENDING')
+  } catch (error) {
+    console.error('Error fetching pending quotes:', error)
+    return []
+  }
+})

--- a/modules/quotes/ui/components/quotes-columns.tsx
+++ b/modules/quotes/ui/components/quotes-columns.tsx
@@ -12,11 +12,36 @@ import { Quote } from '@/modules/quotes/types'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 
-const statusMap = {
-  PENDING: { label: 'Pendiente', variant: 'secondary' as const },
-  APPROVED: { label: 'Aprobada', variant: 'default' as const },
-  REJECTED: { label: 'Rechazada', variant: 'destructive' as const },
-  COMPLETED: { label: 'Completada', variant: 'outline' as const }
+const getStatusBadge = (status: Quote['status']) => {
+  const statusConfig = {
+    PENDING: {
+      label: 'Pendiente',
+      className: 'bg-yellow-500 text-white hover:bg-yellow-600'
+    },
+    APPROVED: {
+      label: 'Aprobada',
+      className: 'bg-green-500 text-white hover:bg-green-600'
+    },
+    REJECTED: {
+      label: 'Rechazada',
+      className: 'bg-red-500 text-white hover:bg-red-600'
+    },
+    COMPLETED: {
+      label: 'Completada',
+      className: 'bg-blue-500 text-white hover:bg-blue-600'
+    }
+  }
+
+  const config = statusConfig[status] || {
+    label: status,
+    className: 'bg-gray-500 text-white'
+  }
+
+  return (
+    <Badge variant='outline' className={config.className}>
+      {config.label}
+    </Badge>
+  )
 }
 
 export const quotesColumns: ColumnDef<Quote>[] = [
@@ -79,16 +104,7 @@ export const quotesColumns: ColumnDef<Quote>[] = [
     accessorKey: 'status',
     header: 'Estado',
     cell: ({ row }) => {
-      const status = row.original.status
-      const statusInfo = statusMap[status]
-      return (
-        <Badge
-          variant={statusInfo.variant}
-          className='bg-yellow-600/80 text-xs font-semibold text-white'
-        >
-          {statusInfo.label}
-        </Badge>
-      )
+      return getStatusBadge(row.original.status)
     }
   },
   {


### PR DESCRIPTION
This pull request introduces a new "Orders" feature for the admin dashboard, enabling admins to view and create orders based on pending quotes. The implementation covers backend data fetching, form validation, server actions, and the necessary UI components. It also updates the admin sidebar to include navigation to the new orders page.

**Orders feature implementation**

* Added the `OrdersPage` route (`app/admin/(routes)/orders/page.tsx`) that displays all orders and pending quotes for admins, using server-side data fetching and suspense for loading states.
* Created server-side queries (`getOrders`, `getOrderById`) to fetch order data securely, with caching and error handling (`modules/orders/server/queries.ts`).
* Defined the order data types, including `Order`, `Address`, and response/input interfaces for consistent type safety (`modules/orders/types.ts`).

**Order creation workflow**

* Implemented form validation schema for creating orders, enforcing required fields and delivery date constraints (`modules/orders/schemas.ts`).
* Added a server action to handle order creation, including authentication, validation, API request, and cache revalidation (`modules/orders/server/actions.ts`).
* Built a client-side order creation form with pending quote selection, delivery date picker, address fields, error handling, and submission logic (`modules/orders/ui/components/order-form.tsx`).

**Admin dashboard navigation**

* Updated the admin sidebar to add an "Órdenes" (Orders) navigation item, including the icon and route (`modules/admin/ui/components/admin-dashboard-sidebar.tsx`). [[1]](diffhunk://#diff-349f17be9f76caa8392d1185c60d0f0831081dea47a352231fc10e7d1308ad69R9) [[2]](diffhunk://#diff-349f17be9f76caa8392d1185c60d0f0831081dea47a352231fc10e7d1308ad69R53-R57)